### PR TITLE
issue:#22/ `Task` 개념 추가

### DIFF
--- a/app/client/main/Section.tsx
+++ b/app/client/main/Section.tsx
@@ -13,7 +13,7 @@ const Section = () => {
         <ServerIcon className="size-[50px]" />
       </div>
       <div>Simulation Time : {clock} seconds </div>
-      <div>Node Status : {nodeStatus} seconds</div>
+      <div>Node Working Core : {nodeStatus}</div>
     </section>
   );
 };

--- a/app/engine/entryPoints.ts
+++ b/app/engine/entryPoints.ts
@@ -1,5 +1,5 @@
 import { Scene } from "./scene";
-import { Node, SimulationClock, type Updatable } from "./updatable";
+import { Node, SimulationClock, Task, type Updatable } from "./updatable";
 import { useMemoryState } from "~/store/memory";
 import * as term from "./term";
 
@@ -43,7 +43,7 @@ class SimulationEngine {
 
 const tickInterval = 100; // 밀리초 단위로 100ms 간격
 const clock = SimulationClock.init();
-const node = Node.boot(2);
+const node = Node.boot(2).registerTask(Task.ready(new term.Second(3)));
 const engine = new SimulationEngine(tickInterval, [clock, node]);
 
 export function start() {

--- a/app/engine/entryPoints.ts
+++ b/app/engine/entryPoints.ts
@@ -1,24 +1,24 @@
 import { Scene } from "./scene";
-import { Node, SimulationClock, type Temporal } from "./updatable";
+import { Node, SimulationClock, type Updatable } from "./updatable";
 import { useMemoryState } from "~/store/memory";
 import * as term from "./term";
 
 class SimulationEngine {
   private intervalId: ReturnType<typeof setInterval> | null = null;
   private tickInterval: number;
-  private temporals: Temporal[];
+  private updatables: Updatable[];
 
-  constructor(tickInterval: number, temporals: Temporal[]) {
+  constructor(tickInterval: number, updatables: Updatable[]) {
     this.tickInterval = tickInterval;
-    this.temporals = temporals;
+    this.updatables = updatables;
   }
 
   start(): void {
     if (this.intervalId !== null) return;
     this.intervalId = setInterval(() => {
       const deltaTime = new term.MilliSecond(this.tickInterval);
-      this.temporals = this.temporals.map((obj) => obj.after(deltaTime));
-      new Scene(this.temporals).publish();
+      this.updatables = this.updatables.map((obj) => obj.after(deltaTime));
+      new Scene(this.updatables).publish();
     }, this.tickInterval);
   }
 
@@ -35,7 +35,7 @@ class SimulationEngine {
     if (this.intervalId !== null) {
       clearInterval(this.intervalId);
       this.intervalId = null;
-      this.temporals = this.temporals.map((obj) => obj.reset());
+      this.updatables = this.updatables.map((obj) => obj.reset());
       console.log("Simulation stopped.");
     }
   }

--- a/app/engine/entryPoints.ts
+++ b/app/engine/entryPoints.ts
@@ -43,7 +43,7 @@ class SimulationEngine {
 
 const tickInterval = 100; // 밀리초 단위로 100ms 간격
 const clock = SimulationClock.init();
-const node = Node.init(new term.Second(3));
+const node = Node.boot(2);
 const engine = new SimulationEngine(tickInterval, [clock, node]);
 
 export function start() {

--- a/app/engine/error.ts
+++ b/app/engine/error.ts
@@ -1,0 +1,13 @@
+export class TraticsError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TraticsError";
+  }
+}
+
+export class TaskStateError extends TraticsError {
+  constructor(message: string) {
+    super(message);
+    this.name = "TaskStateError";
+  }
+}

--- a/app/engine/index.ts
+++ b/app/engine/index.ts
@@ -1,3 +1,4 @@
 import * as time from "./term/time";
+import * as constants from "./term/constants";
 
-export const term = { ...time };
+export const term = { ...time, ...constants };

--- a/app/engine/scene.ts
+++ b/app/engine/scene.ts
@@ -1,23 +1,23 @@
 import { useMemoryState } from "~/store/memory";
-import type { Temporal } from "./updatable";
+import type { Publishable } from "./updatable";
+import * as term from "./term";
 
 export class Scene {
-  temporals: Temporal[];
+  publishables: Publishable[];
 
-  constructor(temporals: Temporal[]) {
-    this.temporals = temporals;
+  constructor(publishables: Publishable[]) {
+    this.publishables = publishables;
   }
 
   publish(): void {
     const state = useMemoryState.getState();
     const handlers = {
-      clock: state.setClock,
-      node: state.setNodeStatus,
+      [term.Role.Clock]: state.setClock,
+      [term.Role.Node]: state.setNodeStatus,
     };
-    this.temporals.reduce((_, temporal) => {
-      const { role, contents } = temporal.publishable();
-      handlers[role]?.(contents);
-      return null;
-    }, null);
+    this.publishables.forEach((publishable) => {
+      const { role, contents } = publishable.state();
+      handlers[role as term.Role]?.(contents);
+    });
   }
 }

--- a/app/engine/term/constants.ts
+++ b/app/engine/term/constants.ts
@@ -1,7 +1,6 @@
 export const enum Role {
   Clock = "clock",
   Node = "node",
-  Task = "task",
 }
 
 export const enum TaskStatus {

--- a/app/engine/term/constants.ts
+++ b/app/engine/term/constants.ts
@@ -1,0 +1,13 @@
+export const enum Role {
+  Clock = "clock",
+  Node = "node",
+  Task = "task",
+}
+
+export const enum TaskStatus {
+  New = "new",
+  Runnable = "runnable",
+  Running = "running",
+  Waiting = "waiting",
+  Terminated = "terminated",
+}

--- a/app/engine/term/constants.ts
+++ b/app/engine/term/constants.ts
@@ -4,9 +4,7 @@ export const enum Role {
 }
 
 export const enum TaskStatus {
-  New = "new",
-  Runnable = "runnable",
+  Ready = "ready",
   Running = "running",
-  Waiting = "waiting",
   Terminated = "terminated",
 }

--- a/app/engine/term/index.ts
+++ b/app/engine/term/index.ts
@@ -1,1 +1,2 @@
 export { Second, MilliSecond } from "./time";
+export { TaskStatus, Role } from "./constants";

--- a/app/engine/updatable/clock.ts
+++ b/app/engine/updatable/clock.ts
@@ -1,11 +1,7 @@
 import * as term from "~/engine/term";
-import {
-  type Temporal,
-  type Publishable,
-  type PublishableState,
-} from "./temporal";
+import { type PublishableState, type Updatable } from "./temporal";
 
-export class SimulationClock implements Temporal, Publishable {
+export class SimulationClock implements Updatable {
   readonly #simulationTime: term.Second;
 
   private constructor(simulationTime: term.Second) {

--- a/app/engine/updatable/clock.ts
+++ b/app/engine/updatable/clock.ts
@@ -1,7 +1,11 @@
 import * as term from "~/engine/term";
-import { type Temporal, type Publishable } from "./temporal";
+import {
+  type Temporal,
+  type Publishable,
+  type PublishableState,
+} from "./temporal";
 
-export class SimulationClock implements Temporal {
+export class SimulationClock implements Temporal, Publishable {
   readonly #simulationTime: term.Second;
 
   private constructor(simulationTime: term.Second) {
@@ -28,9 +32,9 @@ export class SimulationClock implements Temporal {
     return new SimulationClock(new term.Second(0));
   }
 
-  publishable(): Publishable {
+  state(): PublishableState {
     return {
-      role: "clock",
+      role: term.Role.Clock,
       contents: this.#simulationTime.valueOf().toFixed(4),
     };
   }

--- a/app/engine/updatable/index.ts
+++ b/app/engine/updatable/index.ts
@@ -6,3 +6,4 @@ export {
   type Resetable,
   type Updatable,
 } from "./temporal";
+export { Task } from "./task";

--- a/app/engine/updatable/index.ts
+++ b/app/engine/updatable/index.ts
@@ -1,3 +1,8 @@
 export { Node } from "./node";
 export { SimulationClock } from "./clock";
-export { type Temporal, type Publishable } from "./temporal";
+export {
+  type Temporal,
+  type Publishable,
+  type Resetable,
+  type Updatable,
+} from "./temporal";

--- a/app/engine/updatable/index.ts
+++ b/app/engine/updatable/index.ts
@@ -1,3 +1,3 @@
 export { Node } from "./node";
 export { SimulationClock } from "./clock";
-export { type Temporal } from "./temporal";
+export { type Temporal, type Publishable } from "./temporal";

--- a/app/engine/updatable/node.ts
+++ b/app/engine/updatable/node.ts
@@ -3,11 +3,11 @@ import { type PublishableState, type Updatable } from "./temporal";
 import { Task } from "./task";
 
 export class Node implements Updatable {
-  readonly #cores: Array<Task | null>;
+  readonly cores: Array<Task | null>;
   readonly #readyQueue: Task[];
 
   private constructor(cores: Array<Task | null>, taskQueue: Task[]) {
-    this.#cores = cores;
+    this.cores = cores;
     this.#readyQueue = taskQueue;
   }
 
@@ -17,7 +17,7 @@ export class Node implements Updatable {
   }
 
   workingCoreNum(): number {
-    return this.#cores.filter((task) => task !== null).length;
+    return this.cores.filter((task) => task !== null).length;
   }
 
   waitingTaskNum(): number {
@@ -27,12 +27,12 @@ export class Node implements Updatable {
   }
 
   registerTask(task: Task): Node {
-    return new Node(this.#cores, this.#readyQueue.concat(task));
+    return new Node(this.cores, this.#readyQueue.concat(task));
   }
 
   after(deltaTime: term.MilliSecond): Node {
     // 불변성을 위해 데이터 복사
-    const cores = [...this.#cores];
+    const cores = [...this.cores];
     const readyQueue = [...this.#readyQueue];
     const remainingTimePerCore = cores.map(() => deltaTime.valueOf());
 
@@ -130,13 +130,13 @@ export class Node implements Updatable {
   }
 
   reset(): Node {
-    return Node.boot(this.#cores.length);
+    return Node.boot(this.cores.length);
   }
 
   state(): PublishableState {
     return {
       role: term.Role.Node,
-      contents: `${this.workingCoreNum()}/${this.#cores.length}`,
+      contents: `${this.workingCoreNum()}/${this.cores.length}`,
     };
   }
 }

--- a/app/engine/updatable/node.ts
+++ b/app/engine/updatable/node.ts
@@ -31,43 +31,101 @@ export class Node implements Updatable {
   }
 
   after(deltaTime: term.MilliSecond): Node {
-    let deltas = Array(this.#cores.length).fill(deltaTime.valueOf());
-    while (deltas.reduce((acc, cur) => acc + cur, 0) > 0) {
-      for (let i = 0; i < this.#cores.length; i++) {
-        if (this.#cores[i] === null) {
-          if (this.#readyQueue.length === 0) {
-            deltas[i] = 0;
-          } else {
-            const task = (this.#readyQueue.shift() as Task)
-              .start()
-              .after(deltas[i]);
-            if (task.status() === term.TaskStatus.Terminated) {
-              const restDelta =
-                deltas[i] -
-                task.estimatedProcessingDuration().toMilliSeconds().valueOf();
-              deltas[i] = restDelta > 0 ? restDelta : 0;
-              this.#cores[i] = null;
-            } else {
-              deltas[i] = 0;
-              this.#cores[i] = task;
-            }
-          }
-        } else {
-          const task = this.#cores[i] as Task;
-          const restProcessingTime =
-            task.estimatedProcessingDuration().toMilliSeconds().valueOf() -
-            task.elapsedTime().valueOf();
-          const restDelta = deltas[i] - restProcessingTime;
-          if (restDelta > 0) {
-            deltas[i] = restDelta;
-            this.#cores[i] = null;
-          } else {
-            deltas[i] = 0;
-          }
-        }
-      }
+    // 불변성을 위해 데이터 복사
+    const cores = [...this.#cores];
+    const readyQueue = [...this.#readyQueue];
+    const remainingTimePerCore = cores.map(() => deltaTime.valueOf());
+
+    // 모든 코어의 시간을 소비할 때까지 처리
+    while (Node.hasRemainingTime(remainingTimePerCore)) {
+      Node.processAllCores(cores, readyQueue, remainingTimePerCore);
     }
-    return new Node(this.#cores, this.#readyQueue);
+
+    return new Node(cores, readyQueue);
+  }
+
+  // todo: scheduler로 추출해서 구현
+  private static hasRemainingTime(timeArray: number[]): boolean {
+    return timeArray.some((time) => time > 0);
+  }
+
+  private static processAllCores(
+    cores: Array<Task | null>,
+    queue: Task[],
+    remainingTime: number[]
+  ): void {
+    cores.forEach((core, index) => {
+      // 남은 시간이 없으면 처리 건너뛰기
+      if (remainingTime[index] <= 0) return;
+
+      // 코어 상태에 따른 처리
+      if (core === null) {
+        Node.processIdleCore(index, cores, queue, remainingTime);
+      } else {
+        Node.processBusyCore(index, cores, remainingTime);
+      }
+    });
+  }
+
+  private static processIdleCore(
+    index: number,
+    cores: Array<Task | null>,
+    queue: Task[],
+    remainingTime: number[]
+  ): void {
+    // 대기열이 비어있으면 시간 소비하고 종료
+    if (queue.length === 0) {
+      remainingTime[index] = 0;
+      return;
+    }
+
+    // 대기열에서 작업 가져와서 처리 시작
+    const task = queue
+      .shift()!
+      .start()
+      .after(new term.MilliSecond(remainingTime[index]));
+
+    // 작업 상태에 따른 처리
+    if (task.status() === term.TaskStatus.Terminated) {
+      // 작업이 완료된 경우 남은 시간 계산
+      const taskDuration = task
+        .estimatedProcessingDuration()
+        .toMilliSeconds()
+        .valueOf();
+      remainingTime[index] = Math.max(0, remainingTime[index] - taskDuration);
+    } else {
+      // 작업이 아직 실행 중인 경우
+      cores[index] = task;
+      remainingTime[index] = 0;
+    }
+  }
+
+  private static processBusyCore(
+    index: number,
+    cores: Array<Task | null>,
+    remainingTime: number[]
+  ): void {
+    const task = cores[index] as Task;
+
+    // 작업 완료까지 남은 시간 계산
+    const taskRemainingTime = Node.estimateTaskRemainingTime(task);
+
+    // 작업 완료 여부에 따른 처리
+    if (remainingTime[index] > taskRemainingTime) {
+      // 작업이 시간 내에 완료되는 경우
+      remainingTime[index] -= taskRemainingTime;
+      cores[index] = null;
+    } else {
+      // 작업이 계속 실행되는 경우
+      remainingTime[index] = 0;
+    }
+  }
+
+  private static estimateTaskRemainingTime(task: Task): number {
+    return (
+      task.estimatedProcessingDuration().toMilliSeconds().valueOf() -
+      task.elapsedTime().valueOf()
+    );
   }
 
   reset(): Node {

--- a/app/engine/updatable/node.ts
+++ b/app/engine/updatable/node.ts
@@ -1,11 +1,7 @@
 import * as term from "~/engine/term";
-import {
-  type Temporal,
-  type Publishable,
-  type PublishableState,
-} from "./temporal";
+import { type PublishableState, type Updatable } from "./temporal";
 
-export class Node implements Temporal, Publishable {
+export class Node implements Updatable {
   readonly #estimatedProcessingDuration: term.Second;
   readonly #elapsedTime: term.MilliSecond;
   readonly #status: string;

--- a/app/engine/updatable/node.ts
+++ b/app/engine/updatable/node.ts
@@ -1,8 +1,11 @@
-import { useMemoryState } from "~/store/memory";
 import * as term from "~/engine/term";
-import { type Temporal, type Publishable } from "./temporal";
+import {
+  type Temporal,
+  type Publishable,
+  type PublishableState,
+} from "./temporal";
 
-export class Node implements Temporal {
+export class Node implements Temporal, Publishable {
   readonly #estimatedProcessingDuration: term.Second;
   readonly #elapsedTime: term.MilliSecond;
   readonly #status: string;
@@ -49,9 +52,9 @@ export class Node implements Temporal {
     );
   }
 
-  publishable(): Publishable {
+  state(): PublishableState {
     return {
-      role: "node",
+      role: term.Role.Node,
       contents: this.#status,
     };
   }

--- a/app/engine/updatable/node.ts
+++ b/app/engine/updatable/node.ts
@@ -117,6 +117,7 @@ export class Node implements Updatable {
       cores[index] = null;
     } else {
       // 작업이 계속 실행되는 경우
+      cores[index] = task.after(new term.MilliSecond(remainingTime[index]));
       remainingTime[index] = 0;
     }
   }

--- a/app/engine/updatable/task.ts
+++ b/app/engine/updatable/task.ts
@@ -1,0 +1,93 @@
+import { type Temporal } from "./temporal";
+import * as term from "~/engine/term";
+import * as error from "~/engine/error";
+
+export class Task implements Temporal {
+  #estimatedProcessingDuration: term.Second;
+  #elapsedTime: term.MilliSecond;
+  #status: term.TaskStatus;
+
+  private constructor(
+    estimatedProcessingDuration: term.Second,
+    elapsedTime: term.MilliSecond,
+    status: term.TaskStatus
+  ) {
+    this.#estimatedProcessingDuration = estimatedProcessingDuration;
+    this.#elapsedTime = elapsedTime;
+    this.#status = status;
+  }
+
+  static ready(estimatedProcessingDuration: term.Second): Task {
+    return new Task(
+      estimatedProcessingDuration,
+      new term.MilliSecond(0),
+      term.TaskStatus.Ready
+    );
+  }
+
+  status(): string {
+    return this.#status;
+  }
+
+  elapsedTime(): term.MilliSecond {
+    return this.#elapsedTime;
+  }
+
+  after(deltaTime: term.MilliSecond): Task {
+    if (this.#status === term.TaskStatus.Ready) {
+      return new Task(
+        this.#estimatedProcessingDuration,
+        this.#elapsedTime,
+        this.#status
+      );
+    }
+    if (this.#status === term.TaskStatus.Terminated) {
+      throw new error.TaskStateError(
+        `Unable to update task status: task is terminated`
+      );
+    }
+    const elapsedTime = this.#elapsedTime.valueOf() + deltaTime.valueOf();
+    let status: term.TaskStatus = this.#status;
+    if (
+      elapsedTime >=
+      this.#estimatedProcessingDuration.toMilliSeconds().valueOf()
+    ) {
+      status = term.TaskStatus.Terminated;
+    }
+    return new Task(
+      this.#estimatedProcessingDuration,
+      new term.MilliSecond(elapsedTime),
+      status
+    );
+  }
+
+  start(): Task {
+    if (this.#status !== term.TaskStatus.Ready) {
+      throw new error.TaskStateError(
+        `Unable to start task: status must be 'ready', but found '${
+          this.#status
+        }'`
+      );
+    }
+    return new Task(
+      this.#estimatedProcessingDuration,
+      this.#elapsedTime,
+      term.TaskStatus.Running
+    );
+  }
+
+  terminate(): Task {
+    if (this.#status !== term.TaskStatus.Running) {
+      throw new error.TaskStateError(
+        `Unable to terminate task: status must be 'running', but found '${
+          this.#status
+        }'`
+      );
+    }
+    return new Task(
+      this.#estimatedProcessingDuration,
+      this.#elapsedTime,
+      term.TaskStatus.Terminated
+    );
+  }
+}

--- a/app/engine/updatable/task.ts
+++ b/app/engine/updatable/task.ts
@@ -3,9 +3,9 @@ import * as term from "~/engine/term";
 import * as error from "~/engine/error";
 
 export class Task implements Temporal {
-  #estimatedProcessingDuration: term.Second;
-  #elapsedTime: term.MilliSecond;
-  #status: term.TaskStatus;
+  readonly #estimatedProcessingDuration: term.Second;
+  readonly #elapsedTime: term.MilliSecond;
+  readonly #status: term.TaskStatus;
 
   private constructor(
     estimatedProcessingDuration: term.Second,
@@ -31,6 +31,10 @@ export class Task implements Temporal {
 
   elapsedTime(): term.MilliSecond {
     return this.#elapsedTime;
+  }
+
+  estimatedProcessingDuration(): term.Second {
+    return this.#estimatedProcessingDuration;
   }
 
   after(deltaTime: term.MilliSecond): Task {

--- a/app/engine/updatable/temporal.ts
+++ b/app/engine/updatable/temporal.ts
@@ -11,5 +11,13 @@ export interface Publishable {
 
 export interface Temporal {
   after(deltaTime: term.MilliSecond): Temporal;
-  reset(): Temporal;
+}
+
+export interface Resetable {
+  reset(): Resetable;
+}
+
+export interface Updatable extends Temporal, Publishable, Resetable {
+  after(deltaTime: term.MilliSecond): Updatable;
+  reset(): Updatable;
 }

--- a/app/engine/updatable/temporal.ts
+++ b/app/engine/updatable/temporal.ts
@@ -1,12 +1,15 @@
 import * as term from "~/engine/term";
 
-export interface Publishable {
-  role: "clock" | "node";
+export interface PublishableState {
+  role: term.Role;
   contents: string;
+}
+
+export interface Publishable {
+  state(): PublishableState;
 }
 
 export interface Temporal {
   after(deltaTime: term.MilliSecond): Temporal;
   reset(): Temporal;
-  publishable(): Publishable;
 }

--- a/tests/engine/updatable/node.test.ts
+++ b/tests/engine/updatable/node.test.ts
@@ -1,41 +1,96 @@
 import { expect, it, describe } from "vitest";
 import { MilliSecond, Second } from "~/engine/term";
-import { Node } from "~/engine/updatable";
+import { Node, Task } from "~/engine/updatable";
 
-describe("Node.init", () => {
-  it("initialize node instance with 0 elasped timea and idle status", () => {
-    const node = Node.init(new Second(3));
+describe("Node.boot", () => {
+  it("initializes node instance with 0 working cores", () => {
+    const node = Node.boot(2);
 
-    expect(node.status()).toEqual("idle");
-    expect(node.elapsedTime()).toEqual(new MilliSecond(0));
+    expect(node.workingCoreNum()).toEqual(0);
   });
+});
+
+describe("Node.registerTask", () => {
+  it.concurrent.each([
+    [Node.boot(2), Task.ready(new Second(3)), 1],
+    [
+      Node.boot(2).registerTask(Task.ready(new Second(3))),
+      Task.ready(new Second(3)),
+      2,
+    ],
+    [
+      Node.boot(2)
+        .registerTask(Task.ready(new Second(3)))
+        .registerTask(Task.ready(new Second(3))),
+      Task.ready(new Second(3)),
+      3,
+    ],
+  ])(
+    "push a task to the task queue of the node",
+    (node: Node, task: Task, expectedWorkingCoreNum: number) => {
+      const updatedNode = node.registerTask(task);
+
+      expect(updatedNode.waitingTaskNum()).toEqual(expectedWorkingCoreNum);
+    }
+  );
 });
 
 describe("Node.after", () => {
   it.concurrent.each([
-    [Node.init(new Second(3)), new MilliSecond(1), new MilliSecond(1)],
-    [Node.init(new Second(3)), new MilliSecond(3), new MilliSecond(3)],
-    [Node.init(new Second(3)), new MilliSecond(5), new MilliSecond(3)],
+    [
+      Node.boot(2).registerTask(Task.ready(new Second(3))),
+      new MilliSecond(1),
+      0,
+      1,
+    ],
+    [
+      Node.boot(2)
+        .registerTask(Task.ready(new Second(3)))
+        .registerTask(Task.ready(new Second(3))),
+      new MilliSecond(1000),
+      0,
+      2,
+    ],
+    [
+      Node.boot(2)
+        .registerTask(Task.ready(new Second(3)))
+        .registerTask(Task.ready(new Second(3))),
+      new MilliSecond(3000),
+      0,
+      0,
+    ],
+    [
+      Node.boot(2)
+        .registerTask(Task.ready(new Second(3)))
+        .registerTask(Task.ready(new Second(3)))
+        .registerTask(Task.ready(new Second(3))),
+      new MilliSecond(5000),
+      0,
+      1,
+    ],
   ])(
-    "updates the elapsed time by %s",
-    (node: Node, deltaTime: MilliSecond, expectedElapsedTime: MilliSecond) => {
+    "processes tasks correctly after advancing time by %s milliseconds",
+    (
+      node: Node,
+      deltaTime: MilliSecond,
+      expectedWaitingTaskNum: number,
+      expectedWorkingCoreNum: number
+    ) => {
       const updatedNode = node.after(deltaTime);
 
-      expect(updatedNode.elapsedTime()).toEqual(expectedElapsedTime);
+      expect(updatedNode.waitingTaskNum()).toEqual(expectedWaitingTaskNum);
+      expect(updatedNode.workingCoreNum()).toEqual(expectedWorkingCoreNum);
     }
   );
 });
 
 describe("Node.reset", () => {
   it.concurrent.each([
-    [Node.init(new Second(3)), new MilliSecond(0)],
-    [Node.init(new Second(3)).after(new MilliSecond(5)), new MilliSecond(0)],
-  ])(
-    "resets the elapsed time to 0",
-    (node: Node, expectedElapsedTime: MilliSecond) => {
-      const resetNode = node.reset();
+    [Node.boot(2)],
+    [Node.boot(2).after(new MilliSecond(5))],
+  ])("resets the elapsed time to 0", (node: Node) => {
+    const resetNode = node.reset();
 
-      expect(resetNode.elapsedTime()).toEqual(expectedElapsedTime);
-    }
-  );
+    expect(resetNode.workingCoreNum()).toEqual(0);
+  });
 });

--- a/tests/engine/updatable/node.test.ts
+++ b/tests/engine/updatable/node.test.ts
@@ -42,6 +42,7 @@ describe("Node.after", () => {
       new MilliSecond(1),
       0,
       1,
+      [new MilliSecond(2999), undefined],
     ],
     [
       Node.boot(2)
@@ -50,6 +51,7 @@ describe("Node.after", () => {
       new MilliSecond(1000),
       0,
       2,
+      [new MilliSecond(2000), new MilliSecond(2000)],
     ],
     [
       Node.boot(2)
@@ -58,6 +60,7 @@ describe("Node.after", () => {
       new MilliSecond(3000),
       0,
       0,
+      [undefined, undefined],
     ],
     [
       Node.boot(2)
@@ -67,6 +70,7 @@ describe("Node.after", () => {
       new MilliSecond(5000),
       0,
       1,
+      [new MilliSecond(2000), undefined],
     ],
   ])(
     "processes tasks correctly after advancing time by %s milliseconds",
@@ -74,12 +78,16 @@ describe("Node.after", () => {
       node: Node,
       deltaTime: MilliSecond,
       expectedWaitingTaskNum: number,
-      expectedWorkingCoreNum: number
+      expectedWorkingCoreNum: number,
+      expectedCoreElapsedTimes: Array<MilliSecond | undefined>
     ) => {
       const updatedNode = node.after(deltaTime);
 
       expect(updatedNode.waitingTaskNum()).toEqual(expectedWaitingTaskNum);
       expect(updatedNode.workingCoreNum()).toEqual(expectedWorkingCoreNum);
+      expect(updatedNode.cores.map((core) => core?.elapsedTime())).toEqual(
+        expectedCoreElapsedTimes
+      );
     }
   );
 });

--- a/tests/engine/updatable/task.test.ts
+++ b/tests/engine/updatable/task.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { MilliSecond, Second, TaskStatus } from "~/engine/term";
+import { Task } from "~/engine/updatable";
+import * as error from "~/engine/error";
+
+describe("Task.ready", () => {
+  it("should initialize a task with ready status and zero elapsed time", () => {
+    const task = Task.ready(new Second(3));
+
+    expect(task.status()).toEqual(TaskStatus.Ready);
+    expect(task.elapsedTime()).toEqual(new MilliSecond(0));
+  });
+});
+
+describe("Task.start", () => {
+  it("should change the status to running when it is ready", () => {
+    const task = Task.ready(new Second(3)).start();
+
+    expect(task.status()).toEqual(TaskStatus.Running);
+  });
+
+  it.concurrent.each([
+    [Task.ready(new Second(3)).start(), TaskStatus.Running],
+    [Task.ready(new Second(3)).start().terminate(), TaskStatus.Terminated],
+  ])(
+    "should throw task state error when it is not ready",
+    (task: Task, expectedStatus: TaskStatus) => {
+      expect(() => task.start()).toThrowError(
+        new error.TaskStateError(
+          `Unable to start task: status must be 'ready', but found '${expectedStatus}'`
+        )
+      );
+    }
+  );
+});
+
+describe("Task.terminate", () => {
+  it("should change the status to terminated when it is running", () => {
+    const task = Task.ready(new Second(3)).start().terminate();
+
+    expect(task.status()).toEqual(TaskStatus.Terminated);
+  });
+
+  it.concurrent.each([
+    [Task.ready(new Second(3)), TaskStatus.Ready],
+    [Task.ready(new Second(3)).start().terminate(), TaskStatus.Terminated],
+  ])(
+    "should throw task state error when it is not running",
+    (task: Task, expectedStatus: TaskStatus) => {
+      expect(() => task.terminate()).toThrowError(
+        new error.TaskStateError(
+          `Unable to terminate task: status must be 'running', but found '${expectedStatus}'`
+        )
+      );
+    }
+  );
+});
+
+describe("Task.after", () => {
+  it("should not update elapsed time when task is in Ready state", () => {
+    const task = Task.ready(new Second(3));
+    const updatedTask = task.after(new MilliSecond(1000));
+
+    expect(updatedTask.elapsedTime()).toEqual(new MilliSecond(0));
+    expect(updatedTask.status()).toEqual(TaskStatus.Ready);
+  });
+
+  it("should update elapsed time when task is Running", () => {
+    const task = Task.ready(new Second(3)).start();
+    const updatedTask = task.after(new MilliSecond(2000));
+
+    expect(updatedTask.elapsedTime()).toEqual(new MilliSecond(2000));
+    expect(updatedTask.status()).toEqual(TaskStatus.Running);
+  });
+
+  it("should terminate task when elapsed time reaches duration", () => {
+    const task = Task.ready(new Second(3)).start();
+    const updatedTask = task.after(new MilliSecond(3000));
+
+    expect(updatedTask.elapsedTime()).toEqual(new MilliSecond(3000));
+    expect(updatedTask.status()).toEqual(TaskStatus.Terminated);
+  });
+
+  it("should cap elapsed time at duration when delta time exceeds duration", () => {
+    const task = Task.ready(new Second(3)).start();
+    const updatedTask = task.after(new MilliSecond(5000));
+
+    expect(updatedTask.elapsedTime()).toEqual(new MilliSecond(5000));
+    expect(updatedTask.status()).toEqual(TaskStatus.Terminated);
+  });
+
+  it("should throw task state error when task is terminated", () => {
+    const task = Task.ready(new Second(3)).start().terminate();
+
+    expect(() => task.after(new MilliSecond(1000))).toThrowError(
+      new error.TaskStateError(
+        `Unable to update task status: task is terminated`
+      )
+    );
+  });
+});


### PR DESCRIPTION
## 목적

- `Node`의 CPU core를 할당받아 작업을 처리하는 `Task` 개념을 추가합니다.

## 변경 사항

### 도메인

- `Task` 클래스가 추가됩니다.
  - `ready`, `running`, `terminated` 상태를 가집니다.
  - 시간이 경과함에 따라 작업상태가 정책을 따라 변경됩니다.
- `Node` core의 개수를 입력받아 초기화되도록 수정됩니다.
  - `Node`가 직접 작업을 처리하는 것이 아닌, 작업 처리에 대한 책임은 `Task`에 위임합니다.
  - 초기화 시 입력받은 코어의 갯수만큼만 동시에 `Task`를 처리할 수 있습니다.

### FE

- 시뮬레이션 실행 시, 3초 짜리 태스크가 수행되도록 변경됩니다.
  - 현재 사용중인 코어의 갯수를 확인할 수 있습니다.
    
<img width="340" alt="image" src="https://github.com/user-attachments/assets/4417b6c7-935d-4937-96c8-5b002191d2ec" />
