### PR TITLE
issue:#48/ 시뮬레이션 상태 스키마 수정

### DIFF
--- a/app/client/main/Section.tsx
+++ b/app/client/main/Section.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import ClientIcon from "~/client/images/computer-monitor-svgrepo-com.svg?react";
 import ServerIcon from "~/client/images/server-svgrepo-com.svg?react";
-import { useNodeStatus, useMemoryClock, useLinkStatus } from "~/store/memory";
+import { useSimulationTime, useNodes, useLinks } from "~/store/memory";
 import ServerSpec from "../ui/ServerSpec";
 import type { ServerTask } from "../lib/types";
 
@@ -13,15 +13,15 @@ interface SectionProps {
 }
 
 const Section = ({ tasks, isStarted, addTask, deleteTask }: SectionProps) => {
-  const clock = useMemoryClock();
-  const nodeStatus = useNodeStatus();
-  const linkStatus = useLinkStatus();
+  const clock = useSimulationTime();
+  const nodeStatus = useNodes();
+  const linkStatus = useLinks();
 
   const formattedNodeStatus =
     nodeStatus && nodeStatus.length > 0
       ? nodeStatus.map((node: any, index: number) => (
           <React.Fragment key={node.id}>
-            {`${node.busyCores}/${node.cores} cores busy`}
+            [{`${node.cores.map((core: any) => core.status).join(", ")}`}]
             {index < nodeStatus.length - 1 && <br />}
           </React.Fragment>
         ))
@@ -31,7 +31,7 @@ const Section = ({ tasks, isStarted, addTask, deleteTask }: SectionProps) => {
     linkStatus && linkStatus.length > 0
       ? linkStatus.map((link: any, index: number) => (
           <React.Fragment key={link.id}>
-            {`${link.throughput} / ${link.bandwidth} bps`}
+            {`${link.throughput} bps`}
             {index < linkStatus.length - 1 && <br />}
           </React.Fragment>
         ))

--- a/app/engine/core/simulation/scene.ts
+++ b/app/engine/core/simulation/scene.ts
@@ -1,6 +1,5 @@
 import * as term from "~/engine/term";
 import { type Publishable } from "~/engine/interfaces";
-import { useMemoryState } from "~/store/memory";
 
 /**
  * 시뮬레이션 장면을 표현하는 클래스
@@ -31,35 +30,5 @@ export class Scene {
   /**
    * 장면 상태 발행
    */
-  public publish(): void {
-    const { setClock, setNodeStatus, setLinkStatus } =
-      useMemoryState.getState();
-
-    const states = this.#entities.map((entity) => entity.state());
-
-    const clockState = states.find((state) => state.role === term.Role.Clock);
-    setClock((clockState!.currentTime / 1000).toFixed(1));
-
-    const topologyState = states.find(
-      (state) => state.role === term.Role.Topology
-    );
-
-    const nodeStates = topologyState!.nodes;
-    const linkStates = topologyState!.links;
-    const newNodeStates = nodeStates.map((state: any) => ({
-      id: state.id,
-      cores: state.cores.length,
-      busyCores: state.cores.filter((core: any) => core.busy === true).length,
-    }));
-    setNodeStatus(newNodeStates);
-
-    const activeLinks = linkStates.map((state: any) => ({
-      id: state.id,
-      srcId: state.srcId,
-      dstId: state.dstId,
-      bandwidth: state.bandwidth,
-      throughput: state.throughput,
-    }));
-    setLinkStatus(activeLinks);
-  }
+  public publish(): void {}
 }

--- a/app/store/memory.ts
+++ b/app/store/memory.ts
@@ -1,29 +1,27 @@
-// store.ts
 import { create } from "zustand";
 
-interface MemoryState {
-  isRunning: boolean;
-  clock: string;
-  nodeStatus: any;
-  linkStatus: any; // This property is missing in the interface
-  setClock: (clock: string) => void;
-  setNodeStatus: (nodeStatus: any) => void;
-  setLinkStatus: (linkStatus: any) => void;
-  setIsRunning: (isRunning: boolean) => void;
-}
-
-export const useMemoryState = create<MemoryState>((set) => ({
+export const useSimulationMetrics = create<SimulationStatus>((set) => ({
   isRunning: false,
-  clock: "0.0",
-  nodeStatus: null,
-  linkStatus: null,
-  setClock: (clock: string) => set(() => ({ clock })),
-  setNodeStatus: (nodeStatus: any) => set(() => ({ nodeStatus: nodeStatus })),
-  setLinkStatus: (linkStatus: any) => set(() => ({ linkStatus: linkStatus })),
-  setIsRunning: (isRunning: boolean) => set(() => ({ isRunning })),
+  time: "0",
+  totalRequest: 0,
+  successRequest: 0,
+  nodes: [],
+  links: [],
+  setTime: (time: string) => set(() => ({ time })),
+  setTotalRequest: (totalRequest: number) => set(() => ({ totalRequest })),
+  setSuccessRequest: (successRequest: number) =>
+    set(() => ({ successRequest })),
+  setNodes: (nodes: NodeMetrics[]) => set(() => ({ nodes })),
+  setLinks: (links: LinkMetrics[]) => set(() => ({ links })),
 }));
 
-export const useMemoryClock = () => useMemoryState((state) => state.clock);
-export const useNodeStatus = () => useMemoryState((state) => state.nodeStatus);
-export const useLinkStatus = () => useMemoryState((state) => state.linkStatus);
-export const useIsRunning = () => useMemoryState((state) => state.isRunning);
+export const useSimulationTime = () =>
+  useSimulationMetrics((state) => state.time);
+export const useTotalRequest = () =>
+  useSimulationMetrics((state) => state.totalRequest);
+export const useSuccessRequest = () =>
+  useSimulationMetrics((state) => state.successRequest);
+export const useNodes = () => useSimulationMetrics((state) => state.nodes);
+export const useLinks = () => useSimulationMetrics((state) => state.links);
+export const useIsRunning = () =>
+  useSimulationMetrics((state) => state.isRunning);

--- a/app/store/status.ts
+++ b/app/store/status.ts
@@ -1,0 +1,29 @@
+interface CoreStatus {
+  status: "busy" | "idle";
+}
+
+interface NodeMetrics {
+  id: string;
+  cores: CoreStatus[];
+}
+
+interface LinkMetrics {
+  srcId: string;
+  dstId: string;
+  throughput: number;
+}
+
+interface SimulationStatus {
+  isRunning: boolean;
+  time: string;
+  totalRequest: number;
+  successRequest: number;
+  nodes: NodeMetrics[];
+  links: LinkMetrics[];
+
+  setTime: (time: string) => void;
+  setTotalRequest: (totalRequest: number) => void;
+  setSuccessRequest: (successRequest: number) => void;
+  setNodes: (nodes: NodeMetrics[]) => void;
+  setLinks: (links: LinkMetrics[]) => void;
+}


### PR DESCRIPTION
## 목적

- 시뮬레이션의 상태 스키마의 인터페이스를 정의합니다.

## 변경 사항

- `SimulationStatus` 인터페이스가 추가됩니다.
  - 시뮬레이션 내의 경과시간, 요청 수, 노드 및 링크 상태를 게시합니다.

## todo

- 더 이상 사용하지 않는 코드 제거