### PR TITLE
issue: #67/ 시뮬레이션 시간 밀림 현상 수정

### DIFF
--- a/app/engine/engine.ts
+++ b/app/engine/engine.ts
@@ -43,12 +43,6 @@ export class SimulationEngine {
       this.lastTimestamp = timestamp;
     }
     const delta = timestamp - this.lastTimestamp;
-    console.log(
-      `Simulation step: timestamp=${timestamp}, delta=${delta}, elapsedTime=${this.elapsedTime}`
-    );
-    console.log(
-      `Simulation settings: scale=${simulationSettings.simulationScale}, difficulty=${simulationSettings.difficulty}`
-    );
     const effectiveDelta = delta * simulationSettings.simulationScale;
     this.elapsedTime += effectiveDelta;
     this.lastTimestamp = timestamp;

--- a/app/engine/engine.ts
+++ b/app/engine/engine.ts
@@ -1,0 +1,104 @@
+import * as ecsy from "ecsy";
+import { simulationSettings, type SimulationSettings } from "./settings";
+import { createWorld } from "./ecs/world";
+import { InvalidSimulationStatusError } from "./error";
+
+export class SimulationEngine {
+  world: ecsy.World;
+  config: SimulationSettings;
+  elapsedTime: number;
+  lastTimestamp: number | null = null;
+  #rafId: number | null = null;
+
+  constructor(
+    world: ecsy.World,
+    settings: SimulationSettings,
+    elapsedTime: number
+  ) {
+    this.world = world;
+    this.config = settings;
+    this.elapsedTime = elapsedTime;
+    this.step = this.step.bind(this);
+  }
+
+  static init(): SimulationEngine {
+    const world = createWorld();
+    world.stop();
+    return new SimulationEngine(world, structuredClone(simulationSettings), 0);
+  }
+
+  reset(): void {
+    this.world = createWorld();
+    this.config = structuredClone(simulationSettings);
+    this.elapsedTime = 0;
+    this.lastTimestamp = null;
+    if (this.#rafId !== null) {
+      cancelAnimationFrame(this.#rafId);
+      this.#rafId = null;
+    }
+  }
+
+  step(timestamp: number): void {
+    if (this.lastTimestamp === null) {
+      this.lastTimestamp = timestamp;
+    }
+    const delta = timestamp - this.lastTimestamp;
+    console.log(
+      `Simulation step: timestamp=${timestamp}, delta=${delta}, elapsedTime=${this.elapsedTime}`
+    );
+    console.log(
+      `Simulation settings: scale=${simulationSettings.simulationScale}, difficulty=${simulationSettings.difficulty}`
+    );
+    const effectiveDelta = delta * simulationSettings.simulationScale;
+    this.elapsedTime += effectiveDelta;
+    this.lastTimestamp = timestamp;
+    this.world.execute(effectiveDelta, this.elapsedTime);
+
+    this.#rafId = requestAnimationFrame(this.step);
+  }
+
+  start(): void {
+    if (this.world.enabled) {
+      throw new InvalidSimulationStatusError("Simulation is already running.");
+    }
+
+    this.world.play();
+    this.#rafId = requestAnimationFrame(this.step);
+  }
+
+  pause(): void {
+    if (!this.world.enabled) {
+      throw new InvalidSimulationStatusError("Simulation is not running.");
+    }
+
+    if (this.#rafId !== null) {
+      cancelAnimationFrame(this.#rafId);
+      this.#rafId = null;
+    }
+    this.world.stop();
+  }
+
+  resume(): void {
+    if (this.world.enabled) {
+      throw new InvalidSimulationStatusError("Simulation is already running.");
+    }
+
+    this.world.play();
+    this.#rafId = requestAnimationFrame(this.step);
+  }
+
+  stop(): void {
+    if (this.#rafId !== null) {
+      cancelAnimationFrame(this.#rafId);
+      this.#rafId = null;
+    }
+    this.reset();
+    this.world.stop();
+  }
+
+  setSimulationSettings(settings: Partial<SimulationSettings>): void {
+    this.config = { ...this.config, ...settings };
+  }
+}
+
+export const simulationEngine = SimulationEngine.init();

--- a/app/engine/entryPoints.ts
+++ b/app/engine/entryPoints.ts
@@ -1,63 +1,24 @@
-import { SIMULATION_DELTA } from "./constants";
-import { createWorld } from "./ecs/world";
+import { simulationEngine } from "./engine";
 import { simulationSettings } from "./settings";
 
-let world = createWorld();
-let intervalId: ReturnType<typeof setInterval> | null = null;
-
-/**
- * 시뮬레이션 시작
- */
 export function start(): void {
-  let time = 0;
-
-  if (intervalId !== null) {
-    clearInterval(intervalId);
-    intervalId = null;
-  }
-
-  intervalId = setInterval(() => {
-    const effectiveDelta = SIMULATION_DELTA * simulationSettings.simulationScale;
-    world.execute(effectiveDelta, time);
-    time += effectiveDelta;
-  }, SIMULATION_DELTA);
+  simulationEngine.start();
 }
 
-/**
- * 시뮬레이션 일시 중지
- */
 export function pause(): void {
-  world.stop();
-  if (intervalId !== null) {
-    clearInterval(intervalId);
-    intervalId = null;
-  }
+  simulationEngine.pause();
 }
 
 export function resume(): void {
-  world.play();
-  let time = 0;
-  intervalId = setInterval(() => {
-    const effectiveDelta = SIMULATION_DELTA * simulationSettings.simulationScale;
-    world.execute(effectiveDelta, time);
-    time += effectiveDelta;
-  }, SIMULATION_DELTA);
+  simulationEngine.resume();
 }
 
-/**
- * 시뮬레이션 중지 및 초기화
- */
 export function stop(): void {
-  world.stop();
-  world = createWorld();
-  if (intervalId !== null) {
-    clearInterval(intervalId);
-    intervalId = null;
-  }
+  simulationEngine.stop();
 }
 
 export function setSimulationSettings(
   settings: Partial<typeof simulationSettings>
 ): void {
-  Object.assign(simulationSettings, settings);
+  simulationEngine.setSimulationSettings(settings);
 }

--- a/app/engine/error.ts
+++ b/app/engine/error.ts
@@ -39,3 +39,10 @@ export class NotFoundError extends TraticsError {
     this.name = "NotFoundError";
   }
 }
+
+export class InvalidSimulationStatusError extends TraticsError {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidSimulationStatusError";
+  }
+}

--- a/app/engine/settings.ts
+++ b/app/engine/settings.ts
@@ -24,5 +24,5 @@ export const simulationSettings: SimulationSettings = {
   runningStatus: RUNNING_STATUS.STOPPED,
   simulationScale: 1,
   difficulty: SIMULATION_DIFFICULTY.NORMAL,
-  totalRequest: 0,
-}
+  totalRequest: 1000,
+};


### PR DESCRIPTION
## 목적

- 시뮬레이션의 경과시간과 실제 경과시간이 일치하지 않고 시간이 지날수록 시뮬레이션 경과시간이 밀리는 버그를 수정합니다.

## 변경 사항

- `setInterval` 대신 `requestAnimationFrame`을 사용해 시뮬레이션이 진행되도록 변경됩니다.
- 고정된 delta에 기반해 시뮬레이션이 진행되지 않고 실제 경과시간에 기반한 time delta를 기준으로 시뮬레이션이 진행되도록 변경됩니다.