### PR TITLE
simulation config를 store에 저장할 수 있도록 수정

### DIFF
--- a/app/client/main/Header.tsx
+++ b/app/client/main/Header.tsx
@@ -17,6 +17,7 @@ import {
   SelectValue,
 } from "~/components/ui/select";
 import { setSimulationSettings } from "~/engine/entryPoints";
+import { useSimulationScale } from "~/store/memory";
 
 interface HeaderProps {
   status: Status;
@@ -32,7 +33,7 @@ const Header = ({
   onPauseClick,
 }: HeaderProps) => {
   const [requestCounts, setRequestCounts] = useState(DEFAULT_REQUEST_COUNTS);
-  const [speed, setSpeed] = useState(SPPED["1x"]);
+  const speed = useSimulationScale();
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const regExp = /^[0-9]*$/;
@@ -58,7 +59,6 @@ const Header = ({
   };
 
   const onSpeedChange = (value: string) => {
-    setSpeed(+value);
     setSimulationSettings({ simulationScale: +value });
   };
 

--- a/app/client/ui/ServerSpec.tsx
+++ b/app/client/ui/ServerSpec.tsx
@@ -3,9 +3,12 @@ import { Dialog, DialogTrigger } from "~/components/ui/dialog";
 import AddTaskModal from "./AddTaskModal";
 import type { ServerTask, Status } from "../lib/types";
 import { useState } from "react";
-import { useSimulationTime, useSuccessRequest } from "~/store/memory";
+import {
+  useSimulationTime,
+  useSuccessRequest,
+  useTotalRequest,
+} from "~/store/memory";
 import { Progress } from "~/components/ui/progress";
-import { simulationSettings } from "~/engine/settings";
 
 interface ServerSpecProps {
   status: Status;
@@ -22,7 +25,7 @@ const ServerSpec = ({
 }: ServerSpecProps) => {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const time = useSimulationTime();
-  const totalRequests = simulationSettings.totalRequest;
+  const totalRequests = useTotalRequest();
   const successRequests = useSuccessRequest();
 
   const onDialogClose = () => {

--- a/app/engine/entryPoints.ts
+++ b/app/engine/entryPoints.ts
@@ -1,3 +1,4 @@
+import { useSimulationConfig } from "~/store/memory";
 import { simulationEngine } from "./engine";
 import { simulationSettings } from "./settings";
 
@@ -20,5 +21,7 @@ export function stop(): void {
 export function setSimulationSettings(
   settings: Partial<typeof simulationSettings>
 ): void {
+  const { setSimulationConfig } = useSimulationConfig.getState();
+  setSimulationConfig(settings);
   simulationEngine.setSimulationSettings(settings);
 }

--- a/app/store/memory.ts
+++ b/app/store/memory.ts
@@ -1,5 +1,11 @@
 import { create } from "zustand";
-import type { LinkMetrics, NodeMetrics, TemporalStatus } from "./status";
+import type {
+  LinkMetrics,
+  NodeMetrics,
+  SimulationConfig,
+  TemporalStatus,
+} from "./status";
+import type { SimulationSettings } from "~/engine/settings";
 
 export const useSimulationMetrics = create<TemporalStatus>((set) => ({
   time: "0",
@@ -19,3 +25,38 @@ export const useSuccessRequest = () =>
   useSimulationMetrics((state) => state.successRequest);
 export const useNodes = () => useSimulationMetrics((state) => state.nodes);
 export const useLinks = () => useSimulationMetrics((state) => state.links);
+
+export const useSimulationConfig = create<SimulationConfig>((set) => ({
+  totalRequest: 0,
+  simulationScale: 1,
+  difficulty: "normal",
+  runningStatus: "stopped",
+  setTotalRequest: (totalRequest: number) => set(() => ({ totalRequest })),
+  setSimulationScale: (simulationScale: number) =>
+    set(() => ({ simulationScale })),
+  setDifficulty: (difficulty: "easy" | "normal" | "hard") =>
+    set(() => ({ difficulty })),
+  setRunningStatus: (runningStatus: "running" | "paused" | "stopped") =>
+    set(() => ({ runningStatus })),
+  setSimulationConfig: (config: Partial<SimulationSettings>) =>
+    set(() => ({ ...config })),
+}));
+
+export const useTotalRequest = () =>
+  useSimulationConfig((state) => state.totalRequest);
+export const useSimulationScale = () =>
+  useSimulationConfig((state) => state.simulationScale);
+export const useDifficulty = () =>
+  useSimulationConfig((state) => state.difficulty);
+export const useRunningStatus = () =>
+  useSimulationConfig((state) => state.runningStatus);
+export const useSetTotalRequest = () =>
+  useSimulationConfig((state) => state.setTotalRequest);
+export const useSetSimulationScale = () =>
+  useSimulationConfig((state) => state.setSimulationScale);
+export const useSetDifficulty = () =>
+  useSimulationConfig((state) => state.setDifficulty);
+export const useSetRunningStatus = () =>
+  useSimulationConfig((state) => state.setRunningStatus);
+export const useSetSimulationConfig = () =>
+  useSimulationConfig((state) => state.setSimulationConfig);

--- a/app/store/status.ts
+++ b/app/store/status.ts
@@ -1,3 +1,5 @@
+import type { SimulationSettings } from "~/engine/settings";
+
 interface CoreStatus {
   status: "busy" | "idle";
 }
@@ -23,4 +25,12 @@ export interface TemporalStatus {
   setSuccessRequest: (successRequest: number) => void;
   setNodes: (nodes: NodeMetrics[]) => void;
   setLinks: (links: LinkMetrics[]) => void;
+}
+
+export interface SimulationConfig extends SimulationSettings {
+  setTotalRequest: (totalRequest: number) => void;
+  setSimulationScale: (simulationScale: number) => void;
+  setDifficulty: (difficulty: "easy" | "normal" | "hard") => void;
+  setRunningStatus: (runningStatus: "running" | "paused" | "stopped") => void;
+  setSimulationConfig: (config: Partial<SimulationSettings>) => void;
 }


### PR DESCRIPTION
## 목적
- rendering을 적용할 수 있도록 simulation config를 zustand store에 저장하도록 수정합니다.

## 변경 사항
- simulation config zustand store에 추가
- entryPoints에서 setSimulationSettings 시에 store에 값이 저장되도록 수정
- simulationSettings store로 부터 데이터를 받아올 수 있도록 수정