### PR TITLE
issue: #73/ 시뮬레이션 제한 시간 및 서버 코어 개수 설정 기능 추가

### DIFF
--- a/app/engine/ecs/world.ts
+++ b/app/engine/ecs/world.ts
@@ -44,7 +44,7 @@ import {
   ResponseSender,
 } from "./system";
 
-export function createWorld(): ecsy.World {
+export function createWorld(cores: { taskId: string | null }[]): ecsy.World {
   const world = new ecsy.World();
 
   world
@@ -90,7 +90,7 @@ export function createWorld(): ecsy.World {
     .registerSystem(ResponseSender, { priority: 6 })
     .registerSystem(ResponseTransmission, { priority: 7 })
     .registerSystem(SimulationIndicatorRelease, { priority: 8 });
-  
+
   world
     .createEntity()
     .addComponent(Dashboard)
@@ -106,7 +106,7 @@ export function createWorld(): ecsy.World {
     .addComponent(Server)
     .addComponent(ClusterEntryPoint)
     .addComponent(Identity, { id: "server-1" })
-    .addComponent(Cores, { value: [{ taskId: null }, { taskId: null }] })
+    .addComponent(Cores, { value: cores })
     .addComponent(TaskQueue, { tasks: [] });
 
   world

--- a/app/engine/engine.ts
+++ b/app/engine/engine.ts
@@ -22,13 +22,21 @@ export class SimulationEngine {
   }
 
   static init(): SimulationEngine {
-    const world = createWorld();
+    const world = createWorld(
+      Array.from({ length: simulationSettings.nodes[0].coreCount }, () => ({
+        taskId: null,
+      }))
+    );
     world.stop();
     return new SimulationEngine(world, structuredClone(simulationSettings), 0);
   }
 
   reset(): void {
-    this.world = createWorld();
+    this.world = createWorld(
+      Array.from({ length: this.config.nodes[0].coreCount }, () => ({
+        taskId: null,
+      }))
+    );
     this.config = structuredClone(simulationSettings);
     this.elapsedTime = 0;
     this.lastTimestamp = null;

--- a/app/engine/settings.ts
+++ b/app/engine/settings.ts
@@ -13,11 +13,18 @@ export type SimulationDifficulty =
 export type RunningStatus =
   (typeof RUNNING_STATUS)[keyof typeof RUNNING_STATUS];
 
+export interface NodeSpec {
+  id: string;
+  coreCount: number;
+}
+
 export interface SimulationSettings {
   runningStatus: RunningStatus;
   simulationScale: number;
   difficulty: SimulationDifficulty;
   totalRequest: number;
+  timeLimit: number;
+  nodes: NodeSpec[];
 }
 
 export const simulationSettings: SimulationSettings = {
@@ -25,4 +32,6 @@ export const simulationSettings: SimulationSettings = {
   simulationScale: 1,
   difficulty: SIMULATION_DIFFICULTY.NORMAL,
   totalRequest: 1000,
+  timeLimit: 30000, // 30 seconds
+  nodes: [{ id: "node1", coreCount: 4 }],
 };

--- a/app/store/memory.ts
+++ b/app/store/memory.ts
@@ -31,6 +31,8 @@ export const useSimulationConfig = create<SimulationConfig>((set) => ({
   simulationScale: 1,
   difficulty: "normal",
   runningStatus: "stopped",
+  timeLimit: 30000,
+  nodes: [{ id: "node1", coreCount: 4 }],
   setTotalRequest: (totalRequest: number) => set(() => ({ totalRequest })),
   setSimulationScale: (simulationScale: number) =>
     set(() => ({ simulationScale })),


### PR DESCRIPTION
## 목적

- 시뮬레이션 제한 시간 및 서버 코어 개수 설정 기능을 추가합니다.

## 변경 사항

- `SimulationSettings`에 아래와 같은 속성을 추가합니다.
  - `timeLimit: number`
  - `nodes: NodeSpec[]`
- 시뮬레이션 엔진 초기화 시에 `NodeSpec.coreCount`를 참고해 노드의 코어 개수를 초기화합니다.