### PR TITLE
u: 시뮬레이션 결과 메트릭이 시뮬레이션 설정 제한을 넘지않도록 수정

### DIFF
--- a/app/engine/ecs/system.ts
+++ b/app/engine/ecs/system.ts
@@ -596,7 +596,11 @@ export class SimulationIndicatorRelease extends ecsy.System {
     const { setTime, setSuccessRequest, setNodes, setLinks } =
       useSimulationMetrics.getState();
 
-    setTime((time / 1000).toFixed(1));
+    const elapsedTime = Math.min(
+      time / 1000,
+      simulationEngine.config.timeLimit
+    );
+    setTime(elapsedTime.toFixed(1));
     const newNodeStates: NodeMetrics[] = this.queries.servers.results.map(
       (server: ecsy.Entity) => {
         return {
@@ -620,7 +624,11 @@ export class SimulationIndicatorRelease extends ecsy.System {
     );
     setLinks(newLinkStates);
     const dashboard = this.queries.dashboard.results[0];
-    setSuccessRequest(dashboard.getComponent(ProcessedRequestCount)!.value);
+    const successRequests = Math.min(
+      dashboard.getComponent(ProcessedRequestCount)!.value,
+      simulationEngine.config.totalRequest
+    );
+    setSuccessRequest(successRequests);
   }
 }
 


### PR DESCRIPTION
## 목적

- 시뮬레이션에서 처리된 요청 수가 최대 요청 수를 넘지 않도록 수정합니다.

## 변경 사항

- 시뮬레이션에서 처리된 요청 수가 시뮬레이션 config의 최대 요청 수를 넘지 않게 보여주도록 수정됩니다.